### PR TITLE
fix: replace polyfill.io with Cloudflare version

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -14,7 +14,7 @@
     />
     <script
       crossorigin="anonymous"
-      src="https://polyfill.io/v3/polyfill.min.js?features=fetch"
+      src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=fetch"
       defer
     ></script>
     <meta content="width=device-width,initial-scale=1" name="viewport" />


### PR DESCRIPTION
This replaces references to `polyfill.io`, [which is now malware][0], with [Cloudflare's version][1].

*I did not test this manually.*

[0]: https://www.theregister.com/2024/06/25/polyfillio_china_crisis/
[1]: https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet